### PR TITLE
fix Clang warnings:

### DIFF
--- a/utility/mysqldb.hpp
+++ b/utility/mysqldb.hpp
@@ -42,15 +42,15 @@ namespace mysqlpp {
 namespace utility {
 namespace mysql {
     template<typename T>
-    class Tx {
+    struct Tx {
         mysqlpp::Transaction tx_;
         public:
             inline operator mysqlpp::Transaction&() { return tx_; }
     };
     template<typename T>
-    class TxProxy {};
+    struct TxProxy {};
     template<typename T>
-    class TxProxyTraits {};
+    struct TxProxyTraits {};
     class Db {
     public:
         using Query = mysqlpp::Query;


### PR DESCRIPTION
```
vadstena-libs/utility.hpp:83:12: error: class 'TxProxy' was previously declared as a struct; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Werror,-Wmismatched-tags]
    friend class utility::mysql::TxProxy<Utility>;
           ^
```